### PR TITLE
2-missing-namespace-in-function-exists-call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] 2020-10-01
+
+### Fix
+
+- Bug when the `function_exists` statements were missing the namespace `Folded`.
+
 ## [0.1.0] 2020-09-17
 
 ### Added

--- a/src/getDecryptedString.php
+++ b/src/getDecryptedString.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getDecryptedString")) {
+if (!function_exists("Folded\getDecryptedString")) {
     /**
      * Get the decrypted string from an encrypted string.
      *

--- a/src/getEncryptedString.php
+++ b/src/getEncryptedString.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getEncryptedString")) {
+if (!function_exists("Folded\getEncryptedString")) {
     /**
      * Encrypts a strings.
      *

--- a/src/getEncryptionKey.php
+++ b/src/getEncryptionKey.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("getEncryptionKey")) {
+if (!function_exists("Folded\getEncryptionKey")) {
     /**
      * Get a random secure key to be used to encrypt strings with this library.
      *

--- a/src/setEncryptionKey.php
+++ b/src/setEncryptionKey.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Folded;
 
-if (!function_exists("setEncryptionKey")) {
+if (!function_exists("Folded\setEncryptionKey")) {
     /**
      * Set the key that is used as a salt to improve the security of the encrypted strings.
      *


### PR DESCRIPTION
## Added 

None.

## Fixed

- Bug when `function_exists` statements were missing the namespace `Folded`.

## Breaking

None.